### PR TITLE
Minor build fixes: RedisDB arg & update IndexerConfig fields

### DIFF
--- a/src/bin/backfill.rs
+++ b/src/bin/backfill.rs
@@ -29,6 +29,8 @@ fn main() {
         sync_mode: near_indexer::SyncModeEnum::FromInterruption,
         await_for_node_synced: near_indexer::AwaitForNodeSyncedEnum::StreamWhileSyncing,
         validate_genesis: false,
+        interval: Default::default(),
+        finality: Default::default(),
     };
 
     let sys = actix::System::new();

--- a/src/bin/demo.rs
+++ b/src/bin/demo.rs
@@ -1,3 +1,4 @@
+use std::env;
 use dotenv::dotenv;
 
 mod redis_db;
@@ -12,7 +13,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().collect();
     let command = args.get(1).map(|arg| arg.as_str()).unwrap_or("");
 
-    let mut db = redis_db::RedisDB::new().await;
+    // Get env var for Redis URL if set
+    let redis_url_opt: Option<String> = env::var("CACHE_REDIS_URL").ok();
+
+    // Uses CACHE_REDIS_URL env var if it's set, otherwise provides None
+    let mut db = redis_db::RedisDB::new(redis_url_opt).await;
     let stream_key = "test-stream";
 
     match command {

--- a/src/bin/saver.rs
+++ b/src/bin/saver.rs
@@ -35,13 +35,16 @@ async fn main() {
     dotenv().ok();
 
     let path = env::var("DATA_PATH").expect("DATA_PATH is not set");
+    // Get env var for Redis URL if set
+    let redis_url_opt: Option<String> = env::var("CACHE_REDIS_URL").ok();
     let last_block_height = last_block_height(&path);
     let mut last_id = last_block_height
         .map(|h| format!("{}-0", h))
         .unwrap_or("0".to_string());
     println!("Resuming from {}", last_block_height.unwrap_or(0));
 
-    let mut db = RedisDB::new().await;
+    // Uses CACHE_REDIS_URL env var if it's set, otherwise provides None
+    let mut db = RedisDB::new(redis_url_opt).await;
 
     loop {
         let res = db.xread(1, FINAL_BLOCKS_KEY, &last_id).await;


### PR DESCRIPTION
Tried to build this and saw some ez errors.

I suppose there is an assumption in this tiny PR that if the end user has set `CACHE_REDIS_URL` then it should be provided when creating a new `RedisDB` entity.