### PR TITLE
Fix Redis instability issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-node"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Eugene The Dream"]
 rust-version = "1.81.0"
 edition = "2021"

--- a/src/bin/redis_db/mod.rs
+++ b/src/bin/redis_db/mod.rs
@@ -106,6 +106,18 @@ impl RedisDB {
             .collect())
     }
 
+    pub async fn first_id(&mut self, key: &str) -> redis::RedisResult<Option<String>> {
+        let entries: Vec<Entry> = redis::cmd("XRANGE")
+            .arg(key)
+            .arg("-")
+            .arg("+")
+            .arg("COUNT")
+            .arg(1)
+            .query_async(&mut self.connection)
+            .await?;
+        Ok(entries.first().map(|e| e.id().unwrap()))
+    }
+
     pub async fn last_id(&mut self, key: &str) -> redis::RedisResult<Option<String>> {
         let entries: Vec<Entry> = redis::cmd("XREVRANGE")
             .arg(key)


### PR DESCRIPTION
Fix older versions of Redis that don't block for empty XREAD, but returning empty res instead.

Fix blocking at empty queue at start for the new versions of Redis (using XRANGE).