### PR TITLE
Add new last blocks queue for instant block availability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-node"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Eugene The Dream"]
 rust-version = "1.82.0"
 edition = "2021"

--- a/src/bin/caching_saver.rs
+++ b/src/bin/caching_saver.rs
@@ -274,6 +274,15 @@ pub(crate) async fn set_block_and_last_block_height(
             .arg(CACHE_EXPIRATION.as_secs())
             .ignore();
     }
+    pipe.cmd("XADD")
+        .arg(format!("meta:{}:last_blocks_queue", chain_id))
+        .arg("MAXLEN")
+        .arg("~")
+        .arg(10)
+        .arg(format!("{}-0", last_block_height))
+        .arg(&["a", "b"])
+        .ignore();
+
     pipe.cmd("SET")
         .arg(format!("meta:{}:last_block", chain_id))
         .arg(last_block_height)


### PR DESCRIPTION
- Write last block queue that can be awaited against a given height. This is used by neardata server to immediately reply with the block result without timeout