### PR TITLE
Cache expiration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-node"
-version = "0.7.6"
+version = "0.7.7"
 authors = ["Eugene The Dream"]
 rust-version = "1.82.0"
 edition = "2021"


### PR DESCRIPTION
- Add custom cache expiration duration into the config.
- When catching up without read archive, don't store all previous files in memory. Use latest only